### PR TITLE
[HMOA-93 / Feat] 향료 추천 서비스 구현 

### DIFF
--- a/hmoaserver/src/main/java/hmoa/hmoaserver/member/domain/Member.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/member/domain/Member.java
@@ -13,6 +13,7 @@ import hmoa.hmoaserver.perfume.review.domain.PerfumeAge;
 import hmoa.hmoaserver.perfume.review.domain.PerfumeGender;
 import hmoa.hmoaserver.perfume.review.domain.PerfumeWeather;
 import hmoa.hmoaserver.photo.domain.MemberPhoto;
+import hmoa.hmoaserver.recommend.survey.domain.MemberAnswer;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -93,14 +94,17 @@ public class Member extends BaseEntity implements UserDetails {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL , orphanRemoval = true)
     private List<PerfumeAge> perfumeAges = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL , orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PerfumeGender> perfumeGenders = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL , orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PerfumeWeather> perfumeWeathers = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefreshRequest> refreshRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberAnswer> memberAnswers = new ArrayList<>();
 
     public void passwordEncode(PasswordEncoder passwordEncoder){
         this.password = passwordEncoder.encode(this.password);

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/controller/NoteController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/controller/NoteController.java
@@ -4,10 +4,8 @@ import hmoa.hmoaserver.common.PageUtil;
 import hmoa.hmoaserver.common.PagingDto;
 import hmoa.hmoaserver.common.ResultDto;
 import hmoa.hmoaserver.note.domain.Note;
-import hmoa.hmoaserver.note.dto.NoteDefaultResponseDto;
-import hmoa.hmoaserver.note.dto.NoteDetailResponseDto;
-import hmoa.hmoaserver.note.dto.NoteSaveRequestDto;
-import hmoa.hmoaserver.note.dto.NoteUpdateRequestDto;
+import hmoa.hmoaserver.note.dto.*;
+import hmoa.hmoaserver.note.service.DetailNoteService;
 import hmoa.hmoaserver.note.service.NoteService;
 import hmoa.hmoaserver.photo.service.NotePhotoService;
 import hmoa.hmoaserver.photo.service.PhotoService;
@@ -31,6 +29,7 @@ public class NoteController {
     private final NoteService noteService;
     private final PhotoService photoService;
     private final NotePhotoService notePhotoService;
+    private final DetailNoteService detailNoteService;
 
     @ApiOperation("노트 저장")
     @PostMapping("/new")
@@ -116,6 +115,17 @@ public class NoteController {
             photoService.validateFileType(file);
 
             notePhotoService.saveNotePhoto(note, file);
+        }
+
+        return ResponseEntity.ok(ResultDto.builder().build());
+    }
+
+    @ApiOperation("노트 사진 저장")
+    @PostMapping("/detail/save")
+    public ResponseEntity<ResultDto<Object>> saveDetailNote(@PathVariable Long noteId, @RequestBody List<DetailNoteSaveRequestDto> dtos) {
+
+        for (DetailNoteSaveRequestDto dto : dtos) {
+            detailNoteService.save(dto.toEntity());
         }
 
         return ResponseEntity.ok(ResultDto.builder().build());

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/controller/NoteController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/controller/NoteController.java
@@ -3,9 +3,12 @@ package hmoa.hmoaserver.note.controller;
 import hmoa.hmoaserver.common.PageUtil;
 import hmoa.hmoaserver.common.PagingDto;
 import hmoa.hmoaserver.common.ResultDto;
+import hmoa.hmoaserver.note.domain.DetailNote;
 import hmoa.hmoaserver.note.domain.Note;
+import hmoa.hmoaserver.note.domain.NoteDetailNote;
 import hmoa.hmoaserver.note.dto.*;
 import hmoa.hmoaserver.note.service.DetailNoteService;
+import hmoa.hmoaserver.note.service.NoteDetailNoteService;
 import hmoa.hmoaserver.note.service.NoteService;
 import hmoa.hmoaserver.photo.service.NotePhotoService;
 import hmoa.hmoaserver.photo.service.PhotoService;
@@ -30,6 +33,7 @@ public class NoteController {
     private final PhotoService photoService;
     private final NotePhotoService notePhotoService;
     private final DetailNoteService detailNoteService;
+    private final NoteDetailNoteService noteDetailNoteService;
 
     @ApiOperation("노트 저장")
     @PostMapping("/new")
@@ -120,9 +124,9 @@ public class NoteController {
         return ResponseEntity.ok(ResultDto.builder().build());
     }
 
-    @ApiOperation("노트 사진 저장")
+    @ApiOperation("세부 노트 저장")
     @PostMapping("/detail/save")
-    public ResponseEntity<ResultDto<Object>> saveDetailNote(@PathVariable Long noteId, @RequestBody List<DetailNoteSaveRequestDto> dtos) {
+    public ResponseEntity<ResultDto<Object>> saveDetailNote(@RequestBody List<DetailNoteSaveRequestDto> dtos) {
 
         for (DetailNoteSaveRequestDto dto : dtos) {
             detailNoteService.save(dto.toEntity());
@@ -130,4 +134,19 @@ public class NoteController {
 
         return ResponseEntity.ok(ResultDto.builder().build());
     }
+
+    @ApiOperation("노트 세부 노트 매핑")
+    @PostMapping("/{noteId}/detail")
+    public ResponseEntity<ResultDto<Object>> mappingDetailNote(@PathVariable Long noteId, @RequestBody NoteDetailNoteSaveRequestDto dto) {
+        Note note = noteService.findById(noteId);
+
+        for (Long detailNoteId : dto.getDetailNotes()) {
+            DetailNote detailNote = detailNoteService.findById(detailNoteId);
+            NoteDetailNote noteDetailNote = NoteDetailNote.builder().detailNote(detailNote).note(note).build();
+            noteDetailNoteService.save(noteDetailNote);
+        }
+
+        return ResponseEntity.ok(ResultDto.builder().build());
+    }
+
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/controller/NoteController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/controller/NoteController.java
@@ -9,12 +9,15 @@ import hmoa.hmoaserver.note.dto.NoteDetailResponseDto;
 import hmoa.hmoaserver.note.dto.NoteSaveRequestDto;
 import hmoa.hmoaserver.note.dto.NoteUpdateRequestDto;
 import hmoa.hmoaserver.note.service.NoteService;
+import hmoa.hmoaserver.photo.service.NotePhotoService;
+import hmoa.hmoaserver.photo.service.PhotoService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +29,8 @@ import java.util.stream.Collectors;
 public class NoteController {
 
     private final NoteService noteService;
+    private final PhotoService photoService;
+    private final NotePhotoService notePhotoService;
 
     @ApiOperation("노트 저장")
     @PostMapping("/new")
@@ -100,5 +105,19 @@ public class NoteController {
         return ResponseEntity.status(200)
                 .body(ResultDto.builder()
                         .build());
+    }
+
+    @ApiOperation("노트 사진 저장")
+    @PostMapping("/{noteId}/photo")
+    public ResponseEntity<ResultDto<Object>> saveNoteImage(@PathVariable Long noteId, @RequestPart(value="image",required = false) MultipartFile file) {
+        Note note = noteService.findById(noteId);
+        if (file != null) {
+            photoService.validateFileExistence(file);
+            photoService.validateFileType(file);
+
+            notePhotoService.saveNotePhoto(note, file);
+        }
+
+        return ResponseEntity.ok(ResultDto.builder().build());
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/DeatilNote.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/DeatilNote.java
@@ -1,0 +1,21 @@
+package hmoa.hmoaserver.note.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class DeatilNote {
+
+    @Id
+    @Column(name = "detail_note_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String title;
+    private String content;
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/DetailNote.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/DetailNote.java
@@ -3,6 +3,8 @@ package hmoa.hmoaserver.note.domain;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -18,4 +20,7 @@ public class DetailNote {
 
     private String title;
     private String content;
+
+    @OneToMany(mappedBy = "detailNote", cascade = CascadeType.ALL , orphanRemoval = true)
+    private List<NoteDetailNote> noteDetailNotes = new ArrayList<>();
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/DetailNote.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/DetailNote.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class DeatilNote {
+public class DetailNote {
 
     @Id
     @Column(name = "detail_note_id")

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/Note.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/Note.java
@@ -29,6 +29,9 @@ public class Note extends BaseEntity {
     @OneToMany(mappedBy = "note", cascade = CascadeType.ALL , orphanRemoval = true)
     private List<NotePhoto> notePhotos = new ArrayList<>();
 
+    @OneToMany(mappedBy = "note", cascade = CascadeType.ALL , orphanRemoval = true)
+    private List<NoteDetailNote> noteDetailNotes = new ArrayList<>();
+
     public void updateContent(String content) {
         this.content = content;
     }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/Note.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/Note.java
@@ -1,9 +1,12 @@
 package hmoa.hmoaserver.note.domain;
 
 import hmoa.hmoaserver.common.BaseEntity;
+import hmoa.hmoaserver.photo.domain.NotePhoto;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -23,12 +26,25 @@ public class Note extends BaseEntity {
     private String content;
     private boolean isDeleted = false;
 
+    @OneToMany(mappedBy = "note", cascade = CascadeType.ALL , orphanRemoval = true)
+    private List<NotePhoto> notePhotos = new ArrayList<>();
+
     public void updateContent(String content) {
         this.content = content;
     }
 
     public void delete() {
         isDeleted = true;
+    }
+
+    public NotePhoto getNotePhoto() {
+        int size = this.notePhotos.size();
+
+        if (size == 0) {
+            return null;
+        }
+
+        return notePhotos.get(notePhotos.size() - 1);
     }
 
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/NoteDetailNote.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/domain/NoteDetailNote.java
@@ -1,0 +1,33 @@
+package hmoa.hmoaserver.note.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoteDetailNote {
+
+    @Id
+    @Column(name = "note_detail_note_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_id")
+    private Note note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "detail_note_id")
+    private DetailNote detailNote;
+
+    @Builder
+    public NoteDetailNote(Note note, DetailNote detailNote) {
+        this.note = note;
+        this.detailNote = detailNote;
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/DetailNoteSaveRequestDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/DetailNoteSaveRequestDto.java
@@ -1,0 +1,19 @@
+package hmoa.hmoaserver.note.dto;
+
+import hmoa.hmoaserver.note.domain.DetailNote;
+import hmoa.hmoaserver.note.domain.Note;
+import lombok.Data;
+
+@Data
+public class DetailNoteSaveRequestDto {
+
+    private String title;
+    private String content;
+
+    public DetailNote toEntity() {
+        return DetailNote.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/NoteDetailNoteSaveRequestDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/NoteDetailNoteSaveRequestDto.java
@@ -1,0 +1,11 @@
+package hmoa.hmoaserver.note.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class NoteDetailNoteSaveRequestDto {
+
+    private List<Long> detailNotes;
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/NoteSimpleResponseDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/NoteSimpleResponseDto.java
@@ -1,0 +1,15 @@
+package hmoa.hmoaserver.note.dto;
+
+import hmoa.hmoaserver.note.domain.Note;
+import lombok.Data;
+
+@Data
+public class NoteSimpleResponseDto {
+    private String noteName;
+    private String content;
+
+    public NoteSimpleResponseDto(Note note) {
+        this.noteName = note.getTitle();
+        this.content = note.getContent();
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/NoteSimpleResponseDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/dto/NoteSimpleResponseDto.java
@@ -5,11 +5,15 @@ import lombok.Data;
 
 @Data
 public class NoteSimpleResponseDto {
+    private Long noteId;
     private String noteName;
     private String content;
+    private String notePhotoUrl;
 
     public NoteSimpleResponseDto(Note note) {
+        this.noteId = note.getId();
         this.noteName = note.getTitle();
         this.content = note.getContent();
+        this.notePhotoUrl = note.getNotePhoto().getPhotoUrl();
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/repository/DetailNoteRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/repository/DetailNoteRepository.java
@@ -1,0 +1,7 @@
+package hmoa.hmoaserver.note.repository;
+
+import hmoa.hmoaserver.note.domain.DetailNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DetailNoteRepository extends JpaRepository<DetailNote, Long> {
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/repository/NoteDetailNoteRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/repository/NoteDetailNoteRepository.java
@@ -1,0 +1,7 @@
+package hmoa.hmoaserver.note.repository;
+
+import hmoa.hmoaserver.note.domain.NoteDetailNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteDetailNoteRepository extends JpaRepository<NoteDetailNote, Long> {
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/service/DetailNoteService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/service/DetailNoteService.java
@@ -1,0 +1,25 @@
+package hmoa.hmoaserver.note.service;
+
+import hmoa.hmoaserver.exception.Code;
+import hmoa.hmoaserver.exception.CustomException;
+import hmoa.hmoaserver.note.domain.DetailNote;
+import hmoa.hmoaserver.note.repository.DetailNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DetailNoteService {
+
+    private final DetailNoteRepository detailNoteRepository;
+
+    public DetailNote save(DetailNote detailNote) {
+        try {
+            return detailNoteRepository.save(detailNote);
+        } catch (RuntimeException e) {
+            throw new CustomException(e, Code.SERVER_ERROR);
+        }
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/service/DetailNoteService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/service/DetailNoteService.java
@@ -22,4 +22,9 @@ public class DetailNoteService {
             throw new CustomException(e, Code.SERVER_ERROR);
         }
     }
+
+    @Transactional(readOnly = true)
+    public DetailNote findById(Long id) {
+        return detailNoteRepository.findById(id).orElseThrow(() -> new CustomException(null, Code.NOTE_NOT_FOUND));
+    }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/note/service/NoteDetailNoteService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/note/service/NoteDetailNoteService.java
@@ -1,0 +1,25 @@
+package hmoa.hmoaserver.note.service;
+
+import hmoa.hmoaserver.exception.Code;
+import hmoa.hmoaserver.exception.CustomException;
+import hmoa.hmoaserver.note.domain.NoteDetailNote;
+import hmoa.hmoaserver.note.repository.NoteDetailNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoteDetailNoteService {
+
+    private final NoteDetailNoteRepository noteDetailNoteRepository;
+
+    public NoteDetailNote save(NoteDetailNote noteDetailNote) {
+        try {
+            return noteDetailNoteRepository.save(noteDetailNote);
+        } catch (RuntimeException e) {
+            throw new CustomException(e, Code.SERVER_ERROR);
+        }
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/photo/domain/NotePhoto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/photo/domain/NotePhoto.java
@@ -1,0 +1,31 @@
+package hmoa.hmoaserver.photo.domain;
+
+import hmoa.hmoaserver.note.domain.Note;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotePhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_photo_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_id")
+    private Note note;
+
+    private String photoUrl;
+
+    @Builder
+    public NotePhoto(Note note, String photoUrl) {
+        this.note = note;
+        this.photoUrl = photoUrl;
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/photo/repository/NotePhotoRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/photo/repository/NotePhotoRepository.java
@@ -1,0 +1,7 @@
+package hmoa.hmoaserver.photo.repository;
+
+import hmoa.hmoaserver.photo.domain.NotePhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotePhotoRepository extends JpaRepository<NotePhoto, Long> {
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/photo/service/NotePhotoService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/photo/service/NotePhotoService.java
@@ -42,7 +42,7 @@ public class NotePhotoService {
      * 500(SERVER_ERROR)
      */
     @Transactional
-    public NotePhoto saveBrandPhotos(Note note, MultipartFile file) {
+    public NotePhoto saveNotePhoto(Note note, MultipartFile file) {
 
         String folderName = note.getTitle() + "/" + "note-" + note.getId();
         String fileName = UUID.randomUUID() + file.getContentType().replace("image/", ".");

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/photo/service/NotePhotoService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/photo/service/NotePhotoService.java
@@ -1,0 +1,65 @@
+package hmoa.hmoaserver.photo.service;
+
+import hmoa.hmoaserver.exception.CustomException;
+import hmoa.hmoaserver.note.domain.Note;
+import hmoa.hmoaserver.photo.domain.NotePhoto;
+import hmoa.hmoaserver.photo.repository.NotePhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+import static hmoa.hmoaserver.exception.Code.SERVER_ERROR;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotePhotoService {
+
+    @Value("${cloud.aws.s3.bucket-name.note}")
+    private String brandPhotoBucketName;
+    private final PhotoService photoService;
+    private final NotePhotoRepository notePhotoRepository;
+
+    /**
+     * DB에 NotePhoto 저장 |
+     * 500(SERVER_ERROR)
+     */
+    @Transactional
+    public NotePhoto save(NotePhoto photo) {
+        try {
+            return notePhotoRepository.save(photo);
+        } catch (RuntimeException e) {
+            throw new CustomException(e, SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 노트 사진 저장 |
+     * 500(SERVER_ERROR)
+     */
+    @Transactional
+    public NotePhoto saveBrandPhotos(Note note, MultipartFile file) {
+
+        String folderName = note.getTitle() + "/" + "note-" + note.getId();
+        String fileName = UUID.randomUUID() + file.getContentType().replace("image/", ".");
+
+        String brandPhotoUrl = photoService.insertFileToS3(brandPhotoBucketName, folderName, fileName, file);
+
+        NotePhoto notePhoto = null;
+
+        try {
+            notePhoto = notePhoto.builder()
+                    .note(note)
+                    .photoUrl(brandPhotoUrl)
+                    .build();
+        } catch (RuntimeException e) {
+            throw new CustomException(e, SERVER_ERROR);
+        }
+
+        return save(notePhoto);
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
@@ -11,6 +11,7 @@ import hmoa.hmoaserver.recommend.survey.service.*;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +20,7 @@ import java.util.List;
 @Api(tags = {"설문"})
 @RestController
 @RequestMapping("/survey")
+@Slf4j
 @RequiredArgsConstructor
 public class SurveyController {
 
@@ -83,12 +85,18 @@ public class SurveyController {
         Member member = memberService.findByMember(token);
         Answer answer;
 
+        //이미 응답이 존재하면 지우기
+        if (member.getMemberAnswers().size() > 0) {
+            for (MemberAnswer memberAnswer : member.getMemberAnswers()) {
+                memberAnswerService.deleteMemberAnswer(memberAnswer);
+            }
+        }
+
         for (Long optionId : dto.getOptionIds()) {
             answer = answerService.findById(optionId);
 
             memberAnswerService.save(MemberAnswer.builder().member(member).answer(answer).build());
         }
-
         return ResponseEntity.ok(ResultDto.builder().build());
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
@@ -31,6 +31,7 @@ public class SurveyController {
     private final NoteService noteService;
     private final MemberService memberService;
     private final MemberAnswerService memberAnswerService;
+    private final NoteRecommendService noteRecommendService;
 
     @PostMapping("/save")
     public ResponseEntity<ResultDto<Object>> saveSurvey(@RequestBody SurveySaveRequestDto dto) {
@@ -97,6 +98,10 @@ public class SurveyController {
 
             memberAnswerService.save(MemberAnswer.builder().member(member).answer(answer).build());
         }
+
+        List<String> notePoints = noteRecommendService.calculateNoteScoreFromMemberAnswer(member.getMemberAnswers());
+        noteRecommendService.save(notePoints, member);
+
         return ResponseEntity.ok(ResultDto.builder().build());
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
@@ -95,6 +95,14 @@ public class SurveyController {
             }
         }
 
+        //이미 추천 노트가 존재하면 지우기
+        List<NoteRecommend> noteRecommends = noteRecommendService.findByMember(member);
+        if (noteRecommends.size() > 0) {
+            for (NoteRecommend noteRecommend : noteRecommends) {
+                noteRecommendService.delete(noteRecommend);
+            }
+        }
+
         Answer answer;
 
         //optionId로 멤버가 응답한 답변 저장

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/controller/SurveyController.java
@@ -83,14 +83,14 @@ public class SurveyController {
     @PostMapping("/note/respond")
     public ResponseEntity<ResultDto<Object>> respondNoteRecommendSurvey(@RequestHeader("X-AUTH-TOKEN") String token, @RequestBody MemberAnswerRequestDto dto) {
         Member member = memberService.findByMember(token);
-        Answer answer;
-
-        //이미 응답이 존재하면 지우기
-        if (member.getMemberAnswers().size() > 0) {
-            for (MemberAnswer memberAnswer : member.getMemberAnswers()) {
-                memberAnswerService.deleteMemberAnswer(memberAnswer);
+        if (memberAnswerService.isExistingMemberAnswer(member)) {
+            for (MemberAnswer memberAnswer : memberAnswerService.findByMember(member)) {
+                Answer answer = answerService.findById(memberAnswer.getAnswer().getId());
+                memberAnswerService.deleteMemberAnswer(member, answer);
             }
         }
+
+        Answer answer;
 
         for (Long optionId : dto.getOptionIds()) {
             answer = answerService.findById(optionId);

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/Answer.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/Answer.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -22,6 +24,9 @@ public class Answer {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
+
+    @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL , orphanRemoval = true)
+    private List<AnswerNote> answerNotes = new ArrayList<>();
 
     @Builder
     public Answer(String content, Question question) {

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/Answer.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/Answer.java
@@ -28,6 +28,9 @@ public class Answer {
     @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL , orphanRemoval = true)
     private List<AnswerNote> answerNotes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL , orphanRemoval = true)
+    private List<MemberAnswer> memberAnswers = new ArrayList<>();
+
     @Builder
     public Answer(String content, Question question) {
         this.content = content;

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/MemberAnswer.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/MemberAnswer.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -26,6 +28,7 @@ public class MemberAnswer extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Builder

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/NoteRecommend.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/NoteRecommend.java
@@ -1,0 +1,33 @@
+package hmoa.hmoaserver.recommend.survey.domain;
+
+import hmoa.hmoaserver.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoteRecommend {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "note_recommend_id")
+    private Long id;
+
+    @ElementCollection
+    private List<String> recommendNotes;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public NoteRecommend(List<String> recommendNotes, Member member) {
+        this.recommendNotes = recommendNotes;
+        this.member = member;
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/Question.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/domain/Question.java
@@ -15,6 +15,8 @@ public class Question {
     @Column(name = "question_id")
     private Long id;
 
+    private float point;
+
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/AnswerNoteSaveRequestDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/AnswerNoteSaveRequestDto.java
@@ -1,8 +1,5 @@
 package hmoa.hmoaserver.recommend.survey.dto;
 
-import hmoa.hmoaserver.note.domain.Note;
-import hmoa.hmoaserver.recommend.survey.domain.Answer;
-import hmoa.hmoaserver.recommend.survey.domain.AnswerNote;
 import lombok.Data;
 
 @Data

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/AnswerResponseDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/AnswerResponseDto.java
@@ -5,9 +5,11 @@ import lombok.Data;
 
 @Data
 public class AnswerResponseDto {
-    String content;
+    Long optionId;
+    String option;
 
     public AnswerResponseDto(Answer answer) {
-        this.content = answer.getContent();
+        this.optionId = answer.getId();
+        this.option = answer.getContent();
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/MemberAnswerRequestDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/MemberAnswerRequestDto.java
@@ -1,0 +1,12 @@
+package hmoa.hmoaserver.recommend.survey.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+//응답한 옵션 목록 받기
+@Data
+public class MemberAnswerRequestDto {
+
+    private List<Long> optionIds;
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/NoteRecommendResponseDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/NoteRecommendResponseDto.java
@@ -1,0 +1,16 @@
+package hmoa.hmoaserver.recommend.survey.dto;
+
+import hmoa.hmoaserver.note.dto.NoteSimpleResponseDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class NoteRecommendResponseDto {
+
+    private List<NoteSimpleResponseDto> recommendNotes;
+
+    public NoteRecommendResponseDto(List<NoteSimpleResponseDto> recommendNotes) {
+        this.recommendNotes = recommendNotes;
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/QuestionResponseDto.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/dto/QuestionResponseDto.java
@@ -8,10 +8,12 @@ import java.util.stream.Collectors;
 
 @Data
 public class QuestionResponseDto {
+    private Long questionId;
     private String content;
     private List<AnswerResponseDto> answers;
 
     public QuestionResponseDto(Question question) {
+        this.questionId = question.getId();
         this.content = question.getContent();
         this.answers = question.getAnswers().stream().map(AnswerResponseDto::new).collect(Collectors.toList());
     }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/MemberAnswerRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/MemberAnswerRepository.java
@@ -1,11 +1,14 @@
 package hmoa.hmoaserver.recommend.survey.repository;
 
 import hmoa.hmoaserver.member.domain.Member;
+import hmoa.hmoaserver.recommend.survey.domain.Answer;
 import hmoa.hmoaserver.recommend.survey.domain.MemberAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberAnswerRepository extends JpaRepository<MemberAnswer, Long> {
-    Optional<MemberAnswer> findByMember(Member member);
+    List<MemberAnswer> findAllByMember(Member member);
+    Optional<MemberAnswer> findByMemberAndAnswer(Member member, Answer answer);
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/MemberAnswerRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/MemberAnswerRepository.java
@@ -1,7 +1,11 @@
 package hmoa.hmoaserver.recommend.survey.repository;
 
+import hmoa.hmoaserver.member.domain.Member;
 import hmoa.hmoaserver.recommend.survey.domain.MemberAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberAnswerRepository extends JpaRepository<MemberAnswer, Long> {
+    Optional<MemberAnswer> findByMember(Member member);
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/NoteRecommendRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/NoteRecommendRepository.java
@@ -1,0 +1,7 @@
+package hmoa.hmoaserver.recommend.survey.repository;
+
+import hmoa.hmoaserver.recommend.survey.domain.NoteRecommend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRecommendRepository extends JpaRepository<NoteRecommend, Long> {
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/NoteRecommendRepository.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/repository/NoteRecommendRepository.java
@@ -1,7 +1,11 @@
 package hmoa.hmoaserver.recommend.survey.repository;
 
+import hmoa.hmoaserver.member.domain.Member;
 import hmoa.hmoaserver.recommend.survey.domain.NoteRecommend;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NoteRecommendRepository extends JpaRepository<NoteRecommend, Long> {
+    List<NoteRecommend> findAllByMember(Member member);
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/AnswerService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/AnswerService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -24,6 +26,10 @@ public class AnswerService {
         } catch (RuntimeException e) {
             throw new CustomException(e, Code.SERVER_ERROR);
         }
+    }
+
+    public List<Answer> findAll() {
+        return answerRepository.findAll();
     }
 
     public Answer findById(Long id) {

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/MemberAnswerService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/MemberAnswerService.java
@@ -3,22 +3,27 @@ package hmoa.hmoaserver.recommend.survey.service;
 import hmoa.hmoaserver.exception.Code;
 import hmoa.hmoaserver.exception.CustomException;
 import hmoa.hmoaserver.member.domain.Member;
+import hmoa.hmoaserver.recommend.survey.domain.Answer;
 import hmoa.hmoaserver.recommend.survey.domain.MemberAnswer;
 import hmoa.hmoaserver.recommend.survey.repository.MemberAnswerRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Slf4j
+@Transactional
 public class MemberAnswerService {
 
     private final MemberAnswerRepository memberAnswerRepository;
 
-    @Transactional
     public MemberAnswer save(MemberAnswer memberAnswer) {
         try {
             return memberAnswerRepository.save(memberAnswer);
@@ -27,8 +32,25 @@ public class MemberAnswerService {
         }
     }
 
-    @Transactional
-    public void deleteMemberAnswer(MemberAnswer memberAnswer) {
+    public void deleteMemberAnswer(Member member, Answer answer) {
+        MemberAnswer memberAnswer = findByMemberAnswer(member, answer);
 
+        try {
+            memberAnswerRepository.delete(memberAnswer);
+        } catch (DataAccessException | ConstraintViolationException e) {
+            throw new CustomException(null, Code.SERVER_ERROR);
+        }
+    }
+
+    public MemberAnswer findByMemberAnswer(Member member, Answer answer) {
+        return memberAnswerRepository.findByMemberAndAnswer(member, answer).orElseThrow(() -> new CustomException(null, Code.SERVER_ERROR));
+    }
+
+    public List<MemberAnswer> findByMember(Member member) {
+        return memberAnswerRepository.findAllByMember(member);
+    }
+
+    public boolean isExistingMemberAnswer(Member member) {
+        return memberAnswerRepository.findAllByMember(member).size() > 0;
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/MemberAnswerService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/MemberAnswerService.java
@@ -2,11 +2,14 @@ package hmoa.hmoaserver.recommend.survey.service;
 
 import hmoa.hmoaserver.exception.Code;
 import hmoa.hmoaserver.exception.CustomException;
+import hmoa.hmoaserver.member.domain.Member;
 import hmoa.hmoaserver.recommend.survey.domain.MemberAnswer;
 import hmoa.hmoaserver.recommend.survey.repository.MemberAnswerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,5 +25,10 @@ public class MemberAnswerService {
         } catch (RuntimeException e) {
             throw new CustomException(e, Code.SERVER_ERROR);
         }
+    }
+
+    @Transactional
+    public void deleteMemberAnswer(MemberAnswer memberAnswer) {
+
     }
 }

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/NoteRecommendService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/NoteRecommendService.java
@@ -1,0 +1,26 @@
+package hmoa.hmoaserver.recommend.survey.service;
+
+import hmoa.hmoaserver.exception.Code;
+import hmoa.hmoaserver.exception.CustomException;
+import hmoa.hmoaserver.recommend.survey.domain.NoteRecommend;
+import hmoa.hmoaserver.recommend.survey.repository.NoteRecommendRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoteRecommendService {
+
+    private final NoteRecommendRepository noteRecommendRepository;
+
+    @Transactional
+    public NoteRecommend save(NoteRecommend noteRecommend) {
+        try {
+            return noteRecommendRepository.save(noteRecommend);
+        } catch (RuntimeException e) {
+            throw new CustomException(null, Code.SERVER_ERROR);
+        }
+    }
+}

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/NoteRecommendService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/NoteRecommendService.java
@@ -33,6 +33,15 @@ public class NoteRecommendService {
         }
     }
 
+    @Transactional
+    public void delete(NoteRecommend noteRecommend) {
+        noteRecommendRepository.delete(noteRecommend);
+    }
+
+    public List<NoteRecommend> findByMember(Member member) {
+        return noteRecommendRepository.findAllByMember(member);
+    }
+
     public List<String> calculateNoteScoreFromMemberAnswer(List<MemberAnswer> memberAnswers) {
         Map<String, Double> pointMap = new HashMap<>();
         String note;

--- a/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/NoteRecommendService.java
+++ b/hmoaserver/src/main/java/hmoa/hmoaserver/recommend/survey/service/NoteRecommendService.java
@@ -2,11 +2,16 @@ package hmoa.hmoaserver.recommend.survey.service;
 
 import hmoa.hmoaserver.exception.Code;
 import hmoa.hmoaserver.exception.CustomException;
+import hmoa.hmoaserver.note.domain.Note;
+import hmoa.hmoaserver.recommend.survey.domain.AnswerNote;
+import hmoa.hmoaserver.recommend.survey.domain.MemberAnswer;
 import hmoa.hmoaserver.recommend.survey.domain.NoteRecommend;
 import hmoa.hmoaserver.recommend.survey.repository.NoteRecommendRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -22,5 +27,26 @@ public class NoteRecommendService {
         } catch (RuntimeException e) {
             throw new CustomException(null, Code.SERVER_ERROR);
         }
+    }
+
+    public void calculateNoteScoreFromMemberAnswer(List<MemberAnswer> memberAnswers) {
+        Map<Note, Double> pointMap = new HashMap<>();
+        Note note;
+        double point;
+
+        //응답 결과에서 연관된 note 점수 올리기
+        for (MemberAnswer memberAnswer : memberAnswers) {
+            for (AnswerNote answerNote : memberAnswer.getAnswer().getAnswerNotes()) {
+                note = answerNote.getNote();
+                point = answerNote.getAnswer().getQuestion().getPoint();
+
+                pointMap.put(note, pointMap.getOrDefault(note, 0.0) + point);
+            }
+        }
+
+        //pointMap을 내림차순으로 정렬
+        List<Note> keySet = new ArrayList<>(pointMap.keySet());
+
+        keySet.sort((o1, o2) -> pointMap.get(o2).compareTo(pointMap.get(o1)));
     }
 }


### PR DESCRIPTION
## 이슈 번호
- #93 

## 작업 내용
- 향BTI 설문 CRUD 구현
- 설문 기반 향료 추천 알고리즘 구현
- 향료 카테고리 안에 세부 향료 CRUD 구현
- RESTful API로 프론트에게 데이터 전달

## 작업 문서
[Notion](https://atom-baritone-abe.notion.site/0df4a46911ac46c9956d992050bdb08c?pvs=4)